### PR TITLE
Example-Guardian - Update args input for accessing fields

### DIFF
--- a/packages/guardian/example-guardian/save_to_csv.py
+++ b/packages/guardian/example-guardian/save_to_csv.py
@@ -18,16 +18,16 @@ with open('events.csv', 'a') as file:
     if 'from' in args:
         sender = args['from']
     else:
-        sender = args['arg1']
+        sender = args['0']
 
     if 'to' in args:
         receiver = args['to']
     else:
-        receiver = args['arg2']
+        receiver = args['1']
 
     if 'value' in args:
         amount = args['value']
     else:
-        amount = args['arg3']
+        amount = args['2']
 
     writer.writerow({ 'Name': parsed['data']['name'], 'From': sender, 'To': receiver, 'Amount': amount })


### PR DESCRIPTION
Looks like there is a change to the parsed data format of sender, receiver and amount. These changes make sure that the given example script executes as expected.

<img width="686" alt="image" src="https://user-images.githubusercontent.com/86818441/167936338-dc91fb76-9dcb-43d0-95d8-d68f7b4c62f1.png">
